### PR TITLE
HPOS & PHP 8.2 support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: mariankadanka
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=marian.kadanka@gmail.com&item_name=Donation+for+Marian+Kadanka
 Tags: woocommerce, cash, pickup, cop, payment, gateway
 Requires at least: 3.5
-Tested up to: 5.9
-Stable tag: 1.6.1
+Tested up to: 6.3
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,10 @@ The manual installation method involves downloading our plugin and uploading it 
 1. Cash on Pickup settings page
 
 == Changelog ==
+
+= 1.7.0 =
+* Add: HPOS support
+* Tested up to WordPress version 6.3, WooCommerce version 8.1, PHP 8.2
 
 = 1.6.1 =
 * Fix: don't disable other payment methods if Cash On Pickup itself isn't available

--- a/classes/class.wc-cop.php
+++ b/classes/class.wc-cop.php
@@ -37,6 +37,41 @@ if( ! class_exists( 'WC_Gateway_Cash_on_pickup' ) ):
 class WC_Gateway_Cash_on_pickup extends WC_Payment_Gateway {
 
 	/**
+	 * Gateway instructions that will be added to the thank you page and emails.
+	 *
+	 * @var string
+	 */
+	public $instructions;
+
+	/**
+	 * Enable for shipping methods.
+	 *
+	 * @var array
+	 */
+	public $enable_for_methods;
+
+	/**
+	 * Default order status.
+	 *
+	 * @var string
+	 */
+	public $default_order_status;
+
+	/**
+	 * Exclusive for local pickup.
+	 *
+	 * @var string
+	 */
+	public $exclusive_for_local;
+
+	/**
+	 * Enable for virtual orders.
+	 *
+	 * @var string
+	 */
+	public $enable_for_virtual;
+
+	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {

--- a/wc-cash-on-pickup.php
+++ b/wc-cash-on-pickup.php
@@ -3,7 +3,7 @@
 Plugin Name:       WooCommerce Cash On Pickup
 Plugin URI:        https://wordpress.org/plugins/wc-cash-on-pickup/
 Description:       A WooCommerce Extension that adds the payment gateway "Cash On Pickup"
-Version:           1.6.1
+Version:           1.7.0
 Author:            Marian Kadanka
 Author URI:        https://kadanka.net/
 Text Domain:       wc-cash-on-pickup
@@ -11,7 +11,7 @@ Domain Path:       /languages
 License:           GPL-2.0+
 License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
 GitHub Plugin URI: https://github.com/marian-kadanka/wc-cash-on-pickup
-WC tested up to:   6.3
+WC tested up to:   8.1
 */
 
 /**
@@ -81,3 +81,12 @@ function wc_cop_action_links( $links, $file ) {
 	return $links;
 }
 add_filter( 'plugin_action_links', 'wc_cop_action_links', 10, 4 );
+
+/**
+ * Declare WooCommerce HPOS compatibility.
+ */
+add_action( 'before_woocommerce_init', function() {
+	if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
+} );


### PR DESCRIPTION
updated the code to fix deprecated notices in PHP 8.2, declared WooCommerce HPOS support (plugin is well coded, so no need to change anything)